### PR TITLE
test: codec refactoring

### DIFF
--- a/modules/maintainers/auxiliaries/verify/keeper_test.go
+++ b/modules/maintainers/auxiliaries/verify/keeper_test.go
@@ -58,6 +58,7 @@ func Test_auxiliaryKeeper_Help(t *testing.T) {
 	context := sdkTypes.NewContext(commitMultiStore, abciTypes.Header{
 		ChainID: "test",
 	}, false, log.NewNopLogger())
+	Mapper.NewCollection(context).Add(mappable.NewMappable(baseDocuments.NewMaintainer(identityID, classificationID, baseLists.NewPropertyList(mutableProperty).GetPropertyIDList(), permissions)))
 
 	type fields struct {
 		mapper helpers.Mapper
@@ -80,7 +81,6 @@ func Test_auxiliaryKeeper_Help(t *testing.T) {
 			auxiliaryKeeper := auxiliaryKeeper{
 				mapper: tt.fields.mapper,
 			}
-			auxiliaryKeeper.mapper.NewCollection(context).Add(mappable.NewMappable(baseDocuments.NewMaintainer(identityID, classificationID, baseLists.NewPropertyList(mutableProperty).GetPropertyIDList(), permissions)))
 			if got := auxiliaryKeeper.Help(tt.args.context, tt.args.request); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Help() = %v, want %v", got, tt.want)
 			}

--- a/modules/maintainers/auxiliaries/verify/keeper_test.go
+++ b/modules/maintainers/auxiliaries/verify/keeper_test.go
@@ -5,6 +5,8 @@ package verify
 
 import (
 	"fmt"
+	"github.com/AssetMantle/modules/schema"
+	"github.com/cosmos/cosmos-sdk/std"
 	"reflect"
 	"testing"
 
@@ -93,9 +95,12 @@ func Test_auxiliaryKeeper_Initialize(t *testing.T) {
 	paramsStoreKey := sdkTypes.NewKVStoreKey("testParams")
 	paramsTransientStoreKeys := sdkTypes.NewTransientStoreKey("testParamsTransient")
 	Mapper := baseHelpers.NewMapper(key.Prototype, mappable.Prototype).Initialize(storeKey)
-	maintainerCdc := codec.NewLegacyAmino()
+	var legacyAmino = codec.NewLegacyAmino()
+	schema.RegisterLegacyAminoCodec(legacyAmino)
+	std.RegisterLegacyAminoCodec(legacyAmino)
+	legacyAmino.Seal()
 	paramsKeeper := params.NewKeeper(
-		maintainerCdc,
+		legacyAmino,
 		paramsStoreKey,
 		paramsTransientStoreKeys,
 	)

--- a/modules/maintainers/auxiliaries/verify/keeper_test.go
+++ b/modules/maintainers/auxiliaries/verify/keeper_test.go
@@ -93,8 +93,9 @@ func Test_auxiliaryKeeper_Initialize(t *testing.T) {
 	paramsStoreKey := sdkTypes.NewKVStoreKey("testParams")
 	paramsTransientStoreKeys := sdkTypes.NewTransientStoreKey("testParamsTransient")
 	Mapper := baseHelpers.NewMapper(key.Prototype, mappable.Prototype).Initialize(storeKey)
+	maintainerCdc := codec.NewLegacyAmino()
 	paramsKeeper := params.NewKeeper(
-		codec.Cdc,
+		maintainerCdc,
 		paramsStoreKey,
 		paramsTransientStoreKeys,
 	)

--- a/modules/splits/internal/transactions/wrap/keeper_test.go
+++ b/modules/splits/internal/transactions/wrap/keeper_test.go
@@ -190,7 +190,7 @@ func Test_transactionKeeper_Initialize(t *testing.T) {
 		staking.NotBondedPoolName: {supply.Burner, supply.Staking},
 		staking.BondedPoolName:    {supply.Burner, supply.Staking},
 	}
-	supplyKeeper := supply.NewKeeper(codec.Cdc, sdkTypes.NewKVStoreKey(supply.StoreKey), accountKeeper, bankKeeper, maccPerms)
+	supplyKeeper := supply.NewKeeper(codec.NewLegacyAmino(), sdkTypes.NewKVStoreKey(supply.StoreKey), accountKeeper, bankKeeper, maccPerms)
 	type fields struct {
 		mapper                helpers.Mapper
 		parameters            helpers.Parameters

--- a/modules/splits/internal/transactions/wrap/keeper_test.go
+++ b/modules/splits/internal/transactions/wrap/keeper_test.go
@@ -190,7 +190,11 @@ func Test_transactionKeeper_Initialize(t *testing.T) {
 		staking.NotBondedPoolName: {supply.Burner, supply.Staking},
 		staking.BondedPoolName:    {supply.Burner, supply.Staking},
 	}
-	supplyKeeper := supply.NewKeeper(codec.NewLegacyAmino(), sdkTypes.NewKVStoreKey(supply.StoreKey), accountKeeper, bankKeeper, maccPerms)
+	var legacyAmino = codec.NewLegacyAmino()
+	schema.RegisterLegacyAminoCodec(legacyAmino)
+	std.RegisterLegacyAminoCodec(legacyAmino)
+	legacyAmino.Seal()
+	supplyKeeper := supply.NewKeeper(legacyAmino, sdkTypes.NewKVStoreKey(supply.StoreKey), accountKeeper, bankKeeper, maccPerms)
 	type fields struct {
 		mapper                helpers.Mapper
 		parameters            helpers.Parameters


### PR DESCRIPTION
Update  codec to legacy Amino Codec
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and please add links to any
relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
  in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (
  see [PR Targeting](https://github.com/AssetMantle/modules/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines
  for [building modules](https://github.com/AssetMantle/modules/blob/master/docs/building-modules)
- [ ] included the necessary unit and
  integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add your handle next to the items
reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the
  correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)